### PR TITLE
Handle change, min utxo value and spend redeemers in tx-builder 

### DIFF
--- a/rust/crates/cardano-tx-builder/src/cardano/credential.rs
+++ b/rust/crates/cardano-tx-builder/src/cardano/credential.rs
@@ -36,6 +36,14 @@ impl Credential {
 
 // -------------------------------------------------------------------- Building
 
+impl Default for Credential {
+    fn default() -> Self {
+        Self::from_verification_key(Hash::from([
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        ]))
+    }
+}
+
 impl Credential {
     pub fn from_verification_key(hash: Hash<28>) -> Self {
         Self::from(pallas::StakeCredential::AddrKeyhash(pallas::Hash::from(

--- a/rust/crates/cardano-tx-builder/src/cardano/hash.rs
+++ b/rust/crates/cardano-tx-builder/src/cardano/hash.rs
@@ -11,7 +11,7 @@ use std::fmt;
 #[cbor(transparent)]
 pub struct Hash<const SIZE: usize>(#[n(0)] pallas::Hash<SIZE>);
 
-// ------------------------------------------------------------------ Converting
+// ----------------------------------------------------------- Converting (from)
 
 impl<const SIZE: usize> fmt::Display for Hash<SIZE> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
@@ -36,15 +36,9 @@ impl<const SIZE: usize> TryFrom<&str> for Hash<SIZE> {
     }
 }
 
-impl<const SIZE: usize> From<Hash<SIZE>> for pallas::Hash<SIZE> {
-    fn from(hash: Hash<SIZE>) -> Self {
-        hash.0
-    }
-}
-
-impl<const SIZE: usize> From<&Hash<SIZE>> for pallas::Hash<SIZE> {
-    fn from(hash: &Hash<SIZE>) -> Self {
-        hash.0
+impl<const SIZE: usize> From<[u8; SIZE]> for Hash<SIZE> {
+    fn from(hash: [u8; SIZE]) -> Self {
+        Self::from(pallas::Hash::from(hash))
     }
 }
 
@@ -57,5 +51,19 @@ impl<const SIZE: usize> From<pallas::Hash<SIZE>> for Hash<SIZE> {
 impl<const SIZE: usize> From<&pallas::Hash<SIZE>> for Hash<SIZE> {
     fn from(hash: &pallas::Hash<SIZE>) -> Self {
         Self(*hash)
+    }
+}
+
+// ------------------------------------------------------------- Converting (to)
+
+impl<const SIZE: usize> From<Hash<SIZE>> for pallas::Hash<SIZE> {
+    fn from(hash: Hash<SIZE>) -> Self {
+        hash.0
+    }
+}
+
+impl<const SIZE: usize> From<&Hash<SIZE>> for pallas::Hash<SIZE> {
+    fn from(hash: &Hash<SIZE>) -> Self {
+        hash.0
     }
 }

--- a/rust/crates/cardano-tx-builder/src/cardano/macros.rs
+++ b/rust/crates/cardano-tx-builder/src/cardano/macros.rs
@@ -6,7 +6,51 @@ macro_rules! input {
 }
 
 #[macro_export]
+macro_rules! address {
+    ($payment:expr $(,)?) => {
+        $crate::Address::new($crate::NetworkId::mainnet(), $payment)
+    };
+
+    ($network:expr, $payment:expr, $delegation: expr $(,)?) => {
+        $crate::Address<_, $crate::address::Any>::from(
+            $crate::Address::new($crate::NetworkId::mainnet(), $payment).with_delegation($delegation)
+        )
+    };
+}
+
+#[macro_export]
+macro_rules! address_test {
+    ($payment:expr $(,)?) => {
+        $crate::Address::new($crate::NetworkId::testnet(), $payment)
+    };
+
+    ($network:expr, $payment:expr, $delegation: expr $(,)?) => {
+        $crate::Address<_, $crate::address::Any>::from(
+            $crate::Address::new($crate::NetworkId::testnet(), $payment).with_delegation($delegation)
+        )
+    };
+}
+
+#[macro_export]
+macro_rules! script_credential {
+    ($hash:expr $(,)?) => {
+        $crate::Credential::from_script(<$crate::Hash<28>>::try_from($hash).unwrap())
+    };
+}
+
+#[macro_export]
+macro_rules! key_credential {
+    ($hash:expr $(,)?) => {
+        $crate::Credential::from_key(hex::decode($hash).unwrap())
+    };
+}
+
+#[macro_export]
 macro_rules! output {
+    ($addr:expr $(,)?) => {
+        $crate::Output::to($crate::Address::try_from($addr).unwrap())
+    };
+
     ($addr:expr, $value:expr $(,)?) => {
         $crate::Output::new($crate::Address::try_from($addr).unwrap(), $value)
     };

--- a/rust/crates/cardano-tx-builder/src/cardano/macros.rs
+++ b/rust/crates/cardano-tx-builder/src/cardano/macros.rs
@@ -7,6 +7,10 @@ macro_rules! input {
 
 #[macro_export]
 macro_rules! address {
+    ($text:literal $(,)?) => {
+        $crate::Address::try_from($text).unwrap()
+    };
+
     ($payment:expr $(,)?) => {
         $crate::Address::new($crate::NetworkId::mainnet(), $payment)
     };
@@ -20,6 +24,10 @@ macro_rules! address {
 
 #[macro_export]
 macro_rules! address_test {
+    ($text:literal $(,)?) => {
+        $crate::Address::try_from($text).unwrap()
+    };
+
     ($payment:expr $(,)?) => {
         $crate::Address::new($crate::NetworkId::testnet(), $payment)
     };

--- a/rust/crates/cardano-tx-builder/src/cardano/macros.rs
+++ b/rust/crates/cardano-tx-builder/src/cardano/macros.rs
@@ -1,7 +1,17 @@
 #[macro_export]
 macro_rules! input {
     ($tx_hex:expr, $index:expr $(,)?) => {
-        $crate::Input::new(<$crate::Hash<32>>::try_from($tx_hex).unwrap(), $index)
+        (
+            $crate::Input::new(<$crate::Hash<32>>::try_from($tx_hex).unwrap(), $index),
+            None::<$crate::PlutusData>,
+        )
+    };
+
+    ($tx_hex:expr, $index:expr, $redeemer:expr $(,)?) => {
+        (
+            $crate::Input::new(<$crate::Hash<32>>::try_from($tx_hex).unwrap(), $index),
+            Some($redeemer),
+        )
     };
 }
 

--- a/rust/crates/cardano-tx-builder/src/cardano/network_id.rs
+++ b/rust/crates/cardano-tx-builder/src/cardano/network_id.rs
@@ -11,6 +11,18 @@ use std::fmt;
 #[cbor(transparent)]
 pub struct NetworkId(#[n(0)] pallas::NetworkId);
 
+// -------------------------------------------------------------------- Building
+
+impl NetworkId {
+    pub fn mainnet() -> Self {
+        Self(pallas::NetworkId::Mainnet)
+    }
+
+    pub fn testnet() -> Self {
+        Self(pallas::NetworkId::Testnet)
+    }
+}
+
 // ----------------------------------------------------------- Converting (from)
 
 impl From<pallas::NetworkId> for NetworkId {

--- a/rust/crates/cardano-tx-builder/src/cardano/output.rs
+++ b/rust/crates/cardano-tx-builder/src/cardano/output.rs
@@ -2,61 +2,153 @@
 //  License, v. 2.0. If a copy of the MPL was not distributed with this
 //  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use crate::{Address, Value, address, cbor, pallas};
-use std::borrow::Cow;
+use crate::{Address, PlutusScript, Value, address, cbor, cbor::ToCbor, pallas};
+use anyhow::anyhow;
+use std::{borrow::Cow, cell::RefCell, ops::Deref, rc::Rc};
 
-#[derive(Debug)]
-pub struct Output<'a>(Address<'static, address::Any>, Cow<'a, Value<u64>>);
+/// Technically, this is a protocol parameter. It is however usually the same on all networks, and
+/// hasn't changed in many years. If it ever change, we can always adjust the library to the
+/// maximum of the two values. It is much more convenient than carrying protocol parameters around.
+const MIN_VALUE_PER_UTXO_BYTE: u64 = 4310;
 
-// -------------------------------------------------------------------- Building
+/// The CBOR overhead accounting for the in-memory size of inputs and utxo, as per [CIP-0055](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0055#the-new-minimum-lovelace-calculation).
+const MIN_LOVELACE_VALUE_CBOR_OVERHEAD: u64 = 160;
+
+#[derive(Debug, Clone)]
+pub struct Output<'a>(
+    Address<'static, address::Any>,
+    DeferredValue<'a>,
+    Option<Cow<'a, PlutusScript>>,
+);
+
+#[derive(Debug, Clone)]
+enum DeferredValue<'a> {
+    Minimum(RefCell<Rc<Value<u64>>>),
+    Explicit(Cow<'a, Value<u64>>),
+}
+
+// ------------------------------------------------------------------ Inspecting
 
 impl<'a> Output<'a> {
-    pub fn new(address: Address<'static, address::Any>, value: Value<u64>) -> Self {
-        Self(address, Cow::Owned(value))
-    }
-
     pub fn address(&'a self) -> Address<'a, address::Any> {
         self.0.borrow()
     }
 
-    pub fn value(&self) -> &Value<u64> {
-        &self.1
+    pub fn min_acceptable_value(&'a self) -> Value<u64> {
+        Value::new(MIN_VALUE_PER_UTXO_BYTE * (self.size() + MIN_LOVELACE_VALUE_CBOR_OVERHEAD))
+    }
+
+    pub fn value(&'a self) -> Box<dyn AsRef<Value<u64>> + 'a> {
+        match &self.1 {
+            DeferredValue::Minimum(cell) => Box::new(cell.borrow().clone()),
+            DeferredValue::Explicit(value) => Box::new(value),
+        }
+    }
+
+    pub fn script(&'a self) -> Option<&'a PlutusScript> {
+        self.2.as_deref()
+    }
+
+    /// Minimum lovelace value required at a UTxO.
+    fn refresh_minimum_utxo_value(self) -> Self {
+        if let DeferredValue::Minimum(cell) = &self.1 {
+            *cell.borrow_mut() = Rc::new(self.min_acceptable_value());
+        }
+
+        self
+    }
+
+    fn size(&self) -> u64 {
+        self.to_cbor().len() as u64
+    }
+}
+
+// -------------------------------------------------------------------- Building
+
+impl<'a> Output<'a> {
+    /// Construct a new output from an address and a value.
+    pub fn new(address: Address<'static, address::Any>, value: Value<u64>) -> Self {
+        Self(address, DeferredValue::Explicit(Cow::Owned(value)), None)
+    }
+
+    /// Like [`Self::new`], but assumes a minimum Ada value as output.
+    pub fn to(address: Address<'static, address::Any>) -> Self {
+        Self(
+            address,
+            // We use an initial value that's at least 2 ^ 16, so that it is CBOR-encoded over 5
+            // bytes and results in a correct minimum value based on the serialised size.
+            DeferredValue::Minimum(RefCell::new(Rc::new(Value::new(2 ^ 16)))),
+            None,
+        )
+        .refresh_minimum_utxo_value()
+    }
+
+    /// Attach a reference script to the output
+    pub fn with_plutus_script(mut self, plutus_script: PlutusScript) -> Self {
+        self.2 = Some(Cow::Owned(plutus_script));
+        self.refresh_minimum_utxo_value()
     }
 }
 
 // ------------------------------------------------------------ Converting (from)
 
-impl TryFrom<&pallas::TransactionOutput> for Output<'static> {
+impl TryFrom<pallas::TransactionOutput> for Output<'static> {
     type Error = anyhow::Error;
 
-    fn try_from(source: &pallas::TransactionOutput) -> anyhow::Result<Self> {
-        let address = match source {
+    fn try_from(source: pallas::TransactionOutput) -> anyhow::Result<Self> {
+        let (address, value, plutus_script_opt) = match source {
             pallas::TransactionOutput::Legacy(legacy) => {
-                Address::try_from(legacy.address.as_slice())
+                let address = Address::try_from(legacy.address.as_slice())?;
+                let value = Value::from(&legacy.amount);
+                let plutus_script_opt = None;
+
+                Ok::<_, anyhow::Error>((address, value, plutus_script_opt))
             }
+
             pallas::TransactionOutput::PostAlonzo(modern) => {
-                Address::try_from(modern.address.as_slice())
+                let address = Address::try_from(modern.address.as_slice())?;
+                let value = Value::from(&modern.value);
+                let plutus_script_opt = match modern.script_ref.map(|wrap| wrap.unwrap()) {
+                    None => Ok(None),
+                    Some(pallas::ScriptRef::NativeScript(_)) => {
+                        Err(anyhow!("found unsupported native script at output"))
+                    }
+                    Some(pallas::ScriptRef::PlutusV1Script(script)) => {
+                        Ok(Some(PlutusScript::from(script)))
+                    }
+                    Some(pallas::ScriptRef::PlutusV2Script(script)) => {
+                        Ok(Some(PlutusScript::from(script)))
+                    }
+                    Some(pallas::ScriptRef::PlutusV3Script(script)) => {
+                        Ok(Some(PlutusScript::from(script)))
+                    }
+                }?;
+
+                Ok::<_, anyhow::Error>((address, value, plutus_script_opt))
             }
         }?;
 
-        let value = match source {
-            pallas::TransactionOutput::Legacy(legacy) => Value::from(&legacy.amount),
-            pallas::TransactionOutput::PostAlonzo(modern) => Value::from(&modern.value),
-        };
+        let mut output = Output::new(address, value);
 
-        Ok(Output(address, Cow::Owned(value)))
+        if let Some(plutus_script) = plutus_script_opt {
+            output = output.with_plutus_script(plutus_script);
+        }
+
+        Ok(output)
     }
 }
 
 // -------------------------------------------------------------- Converting (to)
 
 impl<'a> From<&Output<'a>> for pallas::TransactionOutput {
-    fn from(Output(address, value): &Output<'a>) -> Self {
+    fn from(output: &Output<'a>) -> Self {
         pallas::TransactionOutput::PostAlonzo(pallas::PostAlonzoTransactionOutput {
-            address: pallas::Bytes::from(<Vec<u8>>::from(address)),
-            value: pallas::Value::from(value.as_ref()),
+            address: pallas::Bytes::from(<Vec<u8>>::from(&output.address())),
+            value: pallas::Value::from(output.value().deref().as_ref()),
             datum_option: None,
-            script_ref: None,
+            script_ref: output
+                .script()
+                .map(|script| pallas::CborWrap(pallas::ScriptRef::from(script.clone()))),
         })
     }
 }
@@ -82,6 +174,6 @@ impl<'a, C> cbor::Encode<C> for Output<'a> {
 impl<'d, C> cbor::Decode<'d, C> for Output<'static> {
     fn decode(d: &mut cbor::Decoder<'d>, ctx: &mut C) -> Result<Self, cbor::decode::Error> {
         let output: pallas::TransactionOutput = d.decode_with(ctx)?;
-        Self::try_from(&output).map_err(cbor::decode::Error::message)
+        Self::try_from(output).map_err(cbor::decode::Error::message)
     }
 }

--- a/rust/crates/cardano-tx-builder/src/cardano/output.rs
+++ b/rust/crates/cardano-tx-builder/src/cardano/output.rs
@@ -6,6 +6,8 @@ use crate::{Address, PlutusScript, Value, address, cbor, cbor::ToCbor, pallas};
 use anyhow::anyhow;
 use std::{borrow::Cow, cell::RefCell, ops::Deref, rc::Rc};
 
+pub mod change_strategy;
+
 /// Technically, this is a protocol parameter. It is however usually the same on all networks, and
 /// hasn't changed in many years. If it ever change, we can always adjust the library to the
 /// maximum of the two values. It is much more convenient than carrying protocol parameters around.

--- a/rust/crates/cardano-tx-builder/src/cardano/output/change_strategy.rs
+++ b/rust/crates/cardano-tx-builder/src/cardano/output/change_strategy.rs
@@ -1,0 +1,59 @@
+//  This Source Code Form is subject to the terms of the Mozilla Public
+//  License, v. 2.0. If a copy of the MPL was not distributed with this
+//  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+use crate::{Address, Output, Value, address};
+use anyhow::anyhow;
+use std::collections::VecDeque;
+
+pub struct ChangeStrategy(
+    #[allow(clippy::type_complexity)]
+    Box<dyn FnOnce(Value<u64>, &mut VecDeque<Output<'static>>) -> anyhow::Result<()>>,
+);
+
+// --------------------------------------------------------------------- Running
+
+impl ChangeStrategy {
+    pub fn with(
+        self,
+        change: Value<u64>,
+        outputs: &mut VecDeque<Output<'static>>,
+    ) -> anyhow::Result<()> {
+        self.0(change, outputs)
+    }
+}
+
+// -------------------------------------------------------------------- Building
+
+impl Default for ChangeStrategy {
+    fn default() -> Self {
+        Self::new(|_change, _outputs| {
+            Err(anyhow!(
+                "no explicit change strategy defined; use 'with_change_strategy' to define one."
+            ))
+        })
+    }
+}
+
+impl ChangeStrategy {
+    pub fn new(
+        strategy: impl FnOnce(Value<u64>, &mut VecDeque<Output<'static>>) -> anyhow::Result<()>
+        + 'static,
+    ) -> Self {
+        Self(Box::new(strategy))
+    }
+
+    pub fn as_last_output(change_address: Address<'static, address::Any>) -> Self {
+        Self::new(move |change, outputs| {
+            outputs.push_back(Output::new(change_address, change));
+            Ok(())
+        })
+    }
+
+    pub fn as_first_output(change_address: Address<'static, address::Any>) -> Self {
+        Self::new(move |change, outputs| {
+            outputs.push_front(Output::new(change_address, change));
+            Ok(())
+        })
+    }
+}

--- a/rust/crates/cardano-tx-builder/src/cardano/plutus_script.rs
+++ b/rust/crates/cardano-tx-builder/src/cardano/plutus_script.rs
@@ -20,6 +20,26 @@ impl PlutusScript {
     }
 }
 
+// ------------------------------------------------------------ Converting (from)
+
+impl From<pallas::PlutusScript<1>> for PlutusScript {
+    fn from(plutus_script: pallas::PlutusScript<1>) -> Self {
+        Self(PlutusVersion::V1, plutus_script.0.to_vec())
+    }
+}
+
+impl From<pallas::PlutusScript<2>> for PlutusScript {
+    fn from(plutus_script: pallas::PlutusScript<2>) -> Self {
+        Self(PlutusVersion::V2, plutus_script.0.to_vec())
+    }
+}
+
+impl From<pallas::PlutusScript<3>> for PlutusScript {
+    fn from(plutus_script: pallas::PlutusScript<3>) -> Self {
+        Self(PlutusVersion::V3, plutus_script.0.to_vec())
+    }
+}
+
 // -------------------------------------------------------------- Converting (to)
 
 impl From<PlutusScript> for Hash<28> {
@@ -33,6 +53,22 @@ impl From<PlutusScript> for Hash<28> {
 pub struct PlutusVersionMismatch {
     pub expected: PlutusVersion,
     pub found: PlutusVersion,
+}
+
+impl From<PlutusScript> for pallas::ScriptRef {
+    fn from(PlutusScript(version, script): PlutusScript) -> Self {
+        match version {
+            PlutusVersion::V1 => pallas::ScriptRef::PlutusV1Script(pallas::PlutusScript::<1>(
+                pallas::Bytes::from(script),
+            )),
+            PlutusVersion::V2 => pallas::ScriptRef::PlutusV2Script(pallas::PlutusScript::<2>(
+                pallas::Bytes::from(script),
+            )),
+            PlutusVersion::V3 => pallas::ScriptRef::PlutusV3Script(pallas::PlutusScript::<3>(
+                pallas::Bytes::from(script),
+            )),
+        }
+    }
 }
 
 impl TryFrom<PlutusScript> for pallas::PlutusScript<1> {

--- a/rust/crates/cardano-tx-builder/src/cardano/protocol_parameters.rs
+++ b/rust/crates/cardano-tx-builder/src/cardano/protocol_parameters.rs
@@ -5,7 +5,7 @@
 #[derive(Debug)]
 pub struct ProtocolParameters {
     /// Multiplier coefficient on fee, in lovelace/bytes
-    fee_coefficient: u64,
+    fee_per_byte: u64,
 
     /// Flat/fixed fee, in lovelace
     fee_constant: u64,
@@ -29,13 +29,14 @@ pub struct ProtocolParameters {
     first_shelley_slot: u64,
 }
 
-type PlutusV3CostModel = [i64; 251];
+type PlutusV3CostModel = [i64; 297];
 
 // ------------------------------------------------------------------ Inspecting
 
 impl ProtocolParameters {
-    pub fn fee(&self) -> (u64, u64) {
-        (self.fee_coefficient, self.fee_constant)
+    /// Base transaction fee, computed from the size of a serialised transaction.
+    pub fn base_fee(&self, size: u64) -> u64 {
+        size * self.fee_per_byte + self.fee_constant
     }
 
     pub fn collateral_coefficient(&self) -> f64 {
@@ -60,7 +61,7 @@ impl ProtocolParameters {
 impl Default for ProtocolParameters {
     fn default() -> Self {
         Self {
-            fee_coefficient: 0,
+            fee_per_byte: 0,
             fee_constant: 0,
             price_mem: 0.0,
             price_cpu: 0.0,
@@ -74,7 +75,9 @@ impl Default for ProtocolParameters {
                 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             ],
             start_time: 0,
             first_shelley_slot: 0,
@@ -83,8 +86,8 @@ impl Default for ProtocolParameters {
 }
 
 impl ProtocolParameters {
-    pub fn with_fee_coefficient(mut self, fee_coefficient: u64) -> Self {
-        self.fee_coefficient = fee_coefficient;
+    pub fn with_fee_per_byte(mut self, fee_per_byte: u64) -> Self {
+        self.fee_per_byte = fee_per_byte;
         self
     }
 

--- a/rust/crates/cardano-tx-builder/src/cardano/transaction.rs
+++ b/rust/crates/cardano-tx-builder/src/cardano/transaction.rs
@@ -3,29 +3,45 @@
 //  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 use crate::{
-    ExecutionUnits, Hash, Input, Output, PlutusData, PlutusScript, PlutusVersion,
+    Address, ExecutionUnits, Hash, Input, Output, PlutusData, PlutusScript, PlutusVersion,
     ProtocolParameters, RedeemerPointer, Value, cbor, pallas,
 };
+use anyhow::anyhow;
 use itertools::Itertools;
-use std::{collections::BTreeMap, ops::Deref};
+use std::{collections::BTreeMap, fmt, mem, ops::Deref};
 
 mod builder;
 
-#[derive(Debug, cbor::Encode, cbor::Decode)]
-#[repr(transparent)]
-#[cbor(transparent)]
-pub struct Transaction(#[n(0)] pallas::Tx);
+pub struct Transaction {
+    inner: pallas::Tx,
+    change_strategy: ChangeStrategy,
+}
+
+pub type ChangeStrategy =
+    Box<dyn FnOnce(Value<u64>, &mut Vec<Output<'static>>) -> anyhow::Result<()>>;
 
 // ------------------------------------------------------------------ Inspecting
 
+impl fmt::Debug for Transaction {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.inner.fmt(f)
+    }
+}
+
 impl Transaction {
+    pub fn id(&self) -> Hash<32> {
+        let mut bytes = Vec::new();
+        let _ = cbor::encode(&self.inner.transaction_body, &mut bytes);
+        Hash::from(pallas::hash::Hasher::<256>::hash(&bytes))
+    }
+
     pub fn fee(&self) -> u64 {
-        self.0.transaction_body.fee
+        self.inner.transaction_body.fee
     }
 
     /// The declared transaction inputs, which are spent in case of successful transaction.
     pub fn inputs(&self) -> Vec<Input<'_>> {
-        self.0
+        self.inner
             .transaction_body
             .inputs
             .deref()
@@ -36,7 +52,7 @@ impl Transaction {
 
     /// The declared transaction collaterals, which are spent in case of failed transaction.
     pub fn collaterals(&self) -> Vec<Input<'_>> {
-        self.0
+        self.inner
             .transaction_body
             .collateral
             .as_ref()
@@ -44,15 +60,291 @@ impl Transaction {
             .unwrap_or_default()
     }
 
+    pub fn mint(&self) -> Value<i64> {
+        self.inner
+            .transaction_body
+            .mint
+            .as_ref()
+            .map(Value::from)
+            .unwrap_or_default()
+    }
+
     /// The declared transaction outputs, which are produced in case of successful transaction.
     pub fn outputs(&self) -> Vec<Output<'_>> {
-        self.0
+        self.inner
             .transaction_body
             .outputs
             .iter()
+            .cloned()
             .map(Output::try_from)
             .collect::<Result<_, _>>()
             .expect("transaction contains invalid outputs; should be impossible at this point.")
+    }
+}
+
+// -------------------------------------------------------------------- Building
+
+impl Default for Transaction {
+    fn default() -> Self {
+        Self {
+            change_strategy: Transaction::default_change_strategy(),
+            inner: pallas::Tx {
+                transaction_body: pallas::TransactionBody {
+                    auxiliary_data_hash: None,
+                    certificates: None,
+                    collateral: None,
+                    collateral_return: None,
+                    donation: None,
+                    fee: 0,
+                    inputs: pallas::Set::from(vec![]),
+                    mint: None,
+                    network_id: None,
+                    outputs: vec![],
+                    proposal_procedures: None,
+                    reference_inputs: None,
+                    required_signers: None,
+                    script_data_hash: None,
+                    total_collateral: None,
+                    treasury_value: None,
+                    ttl: None,
+                    validity_interval_start: None,
+                    voting_procedures: None,
+                    withdrawals: None,
+                },
+                transaction_witness_set: pallas::WitnessSet {
+                    bootstrap_witness: None,
+                    native_script: None,
+                    plutus_data: None,
+                    plutus_v1_script: None,
+                    plutus_v2_script: None,
+                    plutus_v3_script: None,
+                    redeemer: None,
+                    vkeywitness: None,
+                },
+                success: true,
+                auxiliary_data: pallas::Nullable::Null,
+            },
+        }
+    }
+}
+
+impl Transaction {
+    pub fn ok(&mut self) -> anyhow::Result<&mut Self> {
+        Ok(self)
+    }
+
+    pub fn with_inputs<'a>(&mut self, inputs: impl IntoIterator<Item = Input<'a>>) -> &mut Self {
+        self.inner.transaction_body.inputs = pallas::Set::from(
+            inputs
+                .into_iter()
+                .sorted()
+                .map(pallas::TransactionInput::from)
+                .collect::<Vec<_>>(),
+        );
+        self
+    }
+
+    pub fn with_collaterals<'a>(
+        &mut self,
+        collaterals: impl IntoIterator<Item = Input<'a>>,
+    ) -> &mut Self {
+        self.inner.transaction_body.collateral = pallas::NonEmptySet::from_vec(
+            collaterals
+                .into_iter()
+                .sorted()
+                .map(pallas::TransactionInput::from)
+                .collect::<Vec<_>>(),
+        );
+        self
+    }
+
+    pub fn with_outputs<'a>(&mut self, outputs: impl IntoIterator<Item = Output<'a>>) -> &mut Self {
+        self.inner.transaction_body.outputs = outputs
+            .into_iter()
+            .map(pallas::TransactionOutput::from)
+            .collect::<Vec<_>>();
+        self
+    }
+
+    pub fn with_change_strategy(&mut self, with: ChangeStrategy) -> &mut Self {
+        self.change_strategy = with;
+        self
+    }
+
+    pub fn with_mint(
+        &mut self,
+        mint: BTreeMap<(Hash<28>, PlutusData), BTreeMap<Vec<u8>, i64>>,
+    ) -> &mut Self {
+        let (redeemers, mint) = mint.into_iter().enumerate().fold(
+            (BTreeMap::new(), BTreeMap::new()),
+            |(mut redeemers, mut mint), (index, ((policy, data), assets))| {
+                mint.insert(policy, assets);
+
+                redeemers.insert(RedeemerPointer::mint(index as u32), data);
+
+                (redeemers, mint)
+            },
+        );
+
+        let value = Value::default().with_assets(mint);
+
+        self.inner.transaction_body.mint = <Option<pallas::Multiasset<_>>>::from(&value);
+
+        self.with_mint_redeemers(redeemers)
+    }
+
+    pub fn with_fee(&mut self, fee: u64) -> &mut Self {
+        self.inner.transaction_body.fee = fee;
+        self
+    }
+
+    pub fn with_redeemers(
+        &mut self,
+        redeemers: impl IntoIterator<
+            Item = (
+                Box<dyn Fn(&Self) -> anyhow::Result<RedeemerPointer>>,
+                PlutusData,
+            ),
+        >,
+    ) -> anyhow::Result<&mut Self> {
+        let resolved_redeemers = redeemers
+            .into_iter()
+            .map(|(lookup, data)| {
+                let key = pallas::RedeemersKey::from(lookup(self)?);
+
+                let value = pallas::RedeemersValue {
+                    data: pallas::PlutusData::from(data),
+                    ex_units: pallas::ExUnits::from(ExecutionUnits::default()),
+                };
+
+                Ok((key, value))
+            })
+            .collect::<anyhow::Result<Vec<_>>>()?;
+
+        self.inner.transaction_witness_set.redeemer =
+            pallas::NonEmptyKeyValuePairs::from_vec(resolved_redeemers)
+                .map(pallas::Redeemers::from);
+
+        Ok(self)
+    }
+
+    pub fn with_plutus_scripts(
+        &mut self,
+        scripts: impl IntoIterator<Item = PlutusScript>,
+    ) -> &mut Self {
+        let (v1, v2, v3) = scripts.into_iter().fold(
+            (vec![], vec![], vec![]),
+            |(mut v1, mut v2, mut v3), script| {
+                match script.version() {
+                    PlutusVersion::V1 => {
+                        if let Ok(v1_script) = <pallas::PlutusScript<1>>::try_from(script) {
+                            v1.push(v1_script)
+                        }
+                    }
+                    PlutusVersion::V2 => {
+                        if let Ok(v2_script) = <pallas::PlutusScript<2>>::try_from(script) {
+                            v2.push(v2_script)
+                        }
+                    }
+                    PlutusVersion::V3 => {
+                        if let Ok(v3_script) = <pallas::PlutusScript<3>>::try_from(script) {
+                            v3.push(v3_script)
+                        }
+                    }
+                };
+
+                (v1, v2, v3)
+            },
+        );
+
+        assert!(
+            v1.is_empty(),
+            "trying to set some Plutus V1 scripts; these aren't supported yet and may fail later down the builder.",
+        );
+
+        assert!(
+            v2.is_empty(),
+            "trying to set some Plutus V2 scripts; these aren't supported yet and may fail later down the builder.",
+        );
+
+        self.inner.transaction_witness_set.plutus_v1_script = pallas::NonEmptySet::from_vec(v1);
+        self.inner.transaction_witness_set.plutus_v2_script = pallas::NonEmptySet::from_vec(v2);
+        self.inner.transaction_witness_set.plutus_v3_script = pallas::NonEmptySet::from_vec(v3);
+
+        self
+    }
+}
+
+// -------------------------------------------------------------------- Internal
+
+impl Transaction {
+    fn default_change_strategy() -> ChangeStrategy {
+        Box::new(|_change, _outputs| {
+            Err(anyhow!(
+                "no explicit change strategy defined; use 'with_change_strategy' to define one."
+            ))
+        })
+    }
+
+    fn with_change(&mut self, change: Value<u64>) -> anyhow::Result<()> {
+        let min_change_value = Output::new(Address::default(), change.clone())
+            .value()
+            .deref()
+            .as_ref()
+            .lovelace();
+
+        if change.lovelace() < min_change_value {
+            return Err(
+                anyhow!("not enough funds to create a sufficiently large change output").context(
+                    format!(
+                        "current value={} lovelace, minimum required={}",
+                        change.lovelace(),
+                        min_change_value
+                    ),
+                ),
+            );
+        }
+
+        let mut outputs = mem::take(&mut self.inner.transaction_body.outputs)
+            .into_iter()
+            .map(Output::try_from)
+            .collect::<Result<Vec<_>, _>>()?;
+
+        mem::replace(&mut self.change_strategy, Self::default_change_strategy())(
+            change,
+            &mut outputs,
+        )?;
+
+        self.with_outputs(outputs);
+
+        Ok(())
+    }
+
+    fn with_mint_redeemers(
+        &mut self,
+        redeemers: BTreeMap<RedeemerPointer, PlutusData>,
+    ) -> &mut Self {
+        let redeemers = into_pallas_redeemers(redeemers);
+
+        let new_redeemers = if let Some(existing_redeemers) =
+            mem::take(&mut self.inner.transaction_witness_set.redeemer)
+        {
+            let existing_redeemers = without_existing_redeemers(existing_redeemers, |tag| {
+                matches!(tag, pallas::RedeemerTag::Mint)
+            });
+
+            Box::new(existing_redeemers.chain(redeemers))
+                as Box<dyn Iterator<Item = (pallas::RedeemersKey, pallas::RedeemersValue)>>
+        } else {
+            Box::new(redeemers)
+                as Box<dyn Iterator<Item = (pallas::RedeemersKey, pallas::RedeemersValue)>>
+        };
+
+        self.inner.transaction_witness_set.redeemer =
+            pallas::NonEmptyKeyValuePairs::from_vec(new_redeemers.collect())
+                .map(pallas::Redeemers::from);
+
+        self
     }
 
     /// The list of signatories explicitly listed in the transaction body, and visible to any
@@ -65,7 +357,7 @@ impl Transaction {
     /// - 'extra_signatories' (e.g. in Aiken's stdlib: https://aiken-lang.github.io/stdlib/cardano/transaction.html#Transaction
     ///
     fn specified_signatories(&self) -> Vec<Hash<28>> {
-        self.0
+        self.inner
             .transaction_body
             .required_signers
             .as_ref()
@@ -108,7 +400,7 @@ impl Transaction {
             .map(|(index, hash)| (RedeemerPointer::spend(index as u32), hash));
 
         let from_mint = self
-            .0
+            .inner
             .transaction_body
             .mint
             .as_ref()
@@ -122,7 +414,7 @@ impl Transaction {
                     as Box<dyn Iterator<Item = (RedeemerPointer, Hash<28>)>>
             });
 
-        let body = &self.0.transaction_body;
+        let body = &self.inner.transaction_body;
 
         assert!(
             body.certificates.is_none(),
@@ -152,9 +444,9 @@ impl Transaction {
 
     /// Pre-condition: this assumes and only support Plutus V3.
     fn script_integrity_hash(&self, params: &ProtocolParameters) -> Option<Hash<32>> {
-        let redeemers = self.0.transaction_witness_set.redeemer.as_ref();
+        let redeemers = self.inner.transaction_witness_set.redeemer.as_ref();
 
-        let datums = self.0.transaction_witness_set.plutus_data.as_ref();
+        let datums = self.inner.transaction_witness_set.plutus_data.as_ref();
 
         if redeemers.is_none() && datums.is_none() {
             return None;
@@ -179,215 +471,6 @@ impl Transaction {
         .unwrap();
 
         Some(Hash::from(pallas::hash::Hasher::<256>::hash(&preimage)))
-    }
-}
-
-// -------------------------------------------------------------------- Building
-
-impl Default for Transaction {
-    fn default() -> Self {
-        Self(pallas::Tx {
-            transaction_body: pallas::TransactionBody {
-                auxiliary_data_hash: None,
-                certificates: None,
-                collateral: None,
-                collateral_return: None,
-                donation: None,
-                fee: 0,
-                inputs: pallas::Set::from(vec![]),
-                mint: None,
-                network_id: None,
-                outputs: vec![],
-                proposal_procedures: None,
-                reference_inputs: None,
-                required_signers: None,
-                script_data_hash: None,
-                total_collateral: None,
-                treasury_value: None,
-                ttl: None,
-                validity_interval_start: None,
-                voting_procedures: None,
-                withdrawals: None,
-            },
-            transaction_witness_set: pallas::WitnessSet {
-                bootstrap_witness: None,
-                native_script: None,
-                plutus_data: None,
-                plutus_v1_script: None,
-                plutus_v2_script: None,
-                plutus_v3_script: None,
-                redeemer: None,
-                vkeywitness: None,
-            },
-            success: true,
-            auxiliary_data: pallas::Nullable::Null,
-        })
-    }
-}
-
-impl Transaction {
-    pub fn ok(self) -> anyhow::Result<Self> {
-        Ok(self)
-    }
-
-    pub fn with_inputs<'a>(mut self, inputs: impl IntoIterator<Item = Input<'a>>) -> Self {
-        self.0.transaction_body.inputs = pallas::Set::from(
-            inputs
-                .into_iter()
-                .sorted()
-                .map(pallas::TransactionInput::from)
-                .collect::<Vec<_>>(),
-        );
-        self
-    }
-
-    pub fn with_collaterals<'a>(
-        mut self,
-        collaterals: impl IntoIterator<Item = Input<'a>>,
-    ) -> Self {
-        self.0.transaction_body.collateral = pallas::NonEmptySet::from_vec(
-            collaterals
-                .into_iter()
-                .sorted()
-                .map(pallas::TransactionInput::from)
-                .collect::<Vec<_>>(),
-        );
-        self
-    }
-
-    pub fn with_outputs<'a>(mut self, outputs: impl IntoIterator<Item = Output<'a>>) -> Self {
-        self.0.transaction_body.outputs = outputs
-            .into_iter()
-            .map(pallas::TransactionOutput::from)
-            .collect::<Vec<_>>();
-        self
-    }
-
-    pub fn with_mint(
-        mut self,
-        mint: BTreeMap<(Hash<28>, PlutusData), BTreeMap<Vec<u8>, i64>>,
-    ) -> Self {
-        let (redeemers, mint) = mint.into_iter().enumerate().fold(
-            (BTreeMap::new(), BTreeMap::new()),
-            |(mut redeemers, mut mint), (index, ((policy, data), assets))| {
-                mint.insert(policy, assets);
-
-                redeemers.insert(RedeemerPointer::mint(index as u32), data);
-
-                (redeemers, mint)
-            },
-        );
-
-        let value = Value::default().with_assets(mint);
-
-        self.0.transaction_body.mint = <Option<pallas::Multiasset<_>>>::from(&value);
-
-        self.with_mint_redeemers(redeemers)
-    }
-
-    pub fn with_fee(mut self, fee: u64) -> Self {
-        self.0.transaction_body.fee = fee;
-        self
-    }
-
-    pub fn with_redeemers(
-        mut self,
-        redeemers: impl IntoIterator<
-            Item = (
-                Box<dyn Fn(&Self) -> anyhow::Result<RedeemerPointer>>,
-                PlutusData,
-            ),
-        >,
-    ) -> anyhow::Result<Self> {
-        let resolved_redeemers = redeemers
-            .into_iter()
-            .map(|(lookup, data)| {
-                let key = pallas::RedeemersKey::from(lookup(&self)?);
-
-                let value = pallas::RedeemersValue {
-                    data: pallas::PlutusData::from(data),
-                    ex_units: pallas::ExUnits::from(ExecutionUnits::default()),
-                };
-
-                Ok((key, value))
-            })
-            .collect::<anyhow::Result<Vec<_>>>()?;
-
-        self.0.transaction_witness_set.redeemer =
-            pallas::NonEmptyKeyValuePairs::from_vec(resolved_redeemers)
-                .map(pallas::Redeemers::from);
-
-        Ok(self)
-    }
-
-    pub fn with_plutus_scripts(mut self, scripts: impl IntoIterator<Item = PlutusScript>) -> Self {
-        let (v1, v2, v3) = scripts.into_iter().fold(
-            (vec![], vec![], vec![]),
-            |(mut v1, mut v2, mut v3), script| {
-                match script.version() {
-                    PlutusVersion::V1 => {
-                        if let Ok(v1_script) = <pallas::PlutusScript<1>>::try_from(script) {
-                            v1.push(v1_script)
-                        }
-                    }
-                    PlutusVersion::V2 => {
-                        if let Ok(v2_script) = <pallas::PlutusScript<2>>::try_from(script) {
-                            v2.push(v2_script)
-                        }
-                    }
-                    PlutusVersion::V3 => {
-                        if let Ok(v3_script) = <pallas::PlutusScript<3>>::try_from(script) {
-                            v3.push(v3_script)
-                        }
-                    }
-                };
-
-                (v1, v2, v3)
-            },
-        );
-
-        assert!(
-            v1.is_empty(),
-            "trying to set some Plutus V1 scripts; these aren't supported yet and may fail later down the builder.",
-        );
-
-        assert!(
-            v2.is_empty(),
-            "trying to set some Plutus V2 scripts; these aren't supported yet and may fail later down the builder.",
-        );
-
-        self.0.transaction_witness_set.plutus_v1_script = pallas::NonEmptySet::from_vec(v1);
-        self.0.transaction_witness_set.plutus_v2_script = pallas::NonEmptySet::from_vec(v2);
-        self.0.transaction_witness_set.plutus_v3_script = pallas::NonEmptySet::from_vec(v3);
-
-        self
-    }
-}
-
-// -------------------------------------------------------------------- Internal
-
-impl Transaction {
-    fn with_mint_redeemers(mut self, redeemers: BTreeMap<RedeemerPointer, PlutusData>) -> Self {
-        let redeemers = into_pallas_redeemers(redeemers);
-
-        let new_redeemers =
-            if let Some(existing_redeemers) = self.0.transaction_witness_set.redeemer {
-                let existing_redeemers = without_existing_redeemers(existing_redeemers, |tag| {
-                    matches!(tag, pallas::RedeemerTag::Mint)
-                });
-
-                Box::new(existing_redeemers.chain(redeemers))
-                    as Box<dyn Iterator<Item = (pallas::RedeemersKey, pallas::RedeemersValue)>>
-            } else {
-                Box::new(redeemers)
-                    as Box<dyn Iterator<Item = (pallas::RedeemersKey, pallas::RedeemersValue)>>
-            };
-
-        self.0.transaction_witness_set.redeemer =
-            pallas::NonEmptyKeyValuePairs::from_vec(new_redeemers.collect())
-                .map(pallas::Redeemers::from);
-
-        self
     }
 }
 
@@ -418,4 +501,26 @@ fn into_pallas_redeemers(
 
         (key, value)
     })
+}
+
+// -------------------------------------------------------------------- Encoding
+
+impl<C> cbor::Encode<C> for Transaction {
+    fn encode<W: cbor::encode::write::Write>(
+        &self,
+        e: &mut cbor::Encoder<W>,
+        ctx: &mut C,
+    ) -> Result<(), cbor::encode::Error<W::Error>> {
+        e.encode_with(&self.inner, ctx)?;
+        Ok(())
+    }
+}
+
+impl<'d, C> cbor::Decode<'d, C> for Transaction {
+    fn decode(d: &mut cbor::Decoder<'d>, ctx: &mut C) -> Result<Self, cbor::decode::Error> {
+        Ok(Self {
+            inner: d.decode_with(ctx)?,
+            change_strategy: Self::default_change_strategy(),
+        })
+    }
 }

--- a/rust/crates/cardano-tx-builder/src/cardano/transaction/builder.rs
+++ b/rust/crates/cardano-tx-builder/src/cardano/transaction/builder.rs
@@ -393,8 +393,9 @@ fn evaluate_plutus_scripts(
 #[cfg(test)]
 mod tests {
     use crate::{
-        Address, Input, PlutusData, PlutusVersion, ProtocolParameters, Transaction, address,
-        address_test, cbor::ToCbor, input, mint, output, plutus_script, script_credential, value,
+        Address, ChangeStrategy, Input, PlutusData, PlutusVersion, ProtocolParameters, Transaction,
+        address, address_test, cbor::ToCbor, input, mint, output, plutus_script, script_credential,
+        value,
     };
     use std::{collections::BTreeMap, sync::LazyLock};
 
@@ -471,16 +472,9 @@ mod tests {
                         ),
                     ),
                 ])
-                .with_change_strategy(Box::new(|change, outputs| {
-                    outputs.push(
-                        output!(
-                            "addr1qxjgtdjrdj05nge3v406z46yqhp7nwc744j7sju37287sfjrcq0durn7xns7whpp6mymksagz9msf08qxqfakhc85dgq9pynjj",
-                            change,
-                        ),
-                    );
-
-                    Ok(())
-                }))
+                .with_change_strategy(ChangeStrategy::as_last_output(
+                    address!("addr1qxjgtdjrdj05nge3v406z46yqhp7nwc744j7sju37287sfjrcq0durn7xns7whpp6mymksagz9msf08qxqfakhc85dgq9pynjj")
+                ))
                 .ok()
         });
 
@@ -520,15 +514,11 @@ mod tests {
                 .with_collaterals(vec![
                     input!("d62db0b98b6df96645eec19d4728b385592fc531736abd987eb6490510c5ba50", 0),
                 ])
-                .with_change_strategy(Box::new(|change, outputs| {
-                    outputs.push(
-                        output!(
-                            "addr1qxu84ftxpzh3zd8p9awp2ytwzk5exj0fxcj7paur4kd4ytun36yuhgl049rxhhuckm2lpq3rmz5dcraddyl45d6xgvqqsp504c",
-                            change,
-                        )
-                    );
-                    Ok(())
-                }))
+                .with_change_strategy(ChangeStrategy::as_last_output(
+                    address!(
+                        "addr1qxu84ftxpzh3zd8p9awp2ytwzk5exj0fxcj7paur4kd4ytun36yuhgl049rxhhuckm2lpq3rmz5dcraddyl45d6xgvqqsp504c",
+                    )
+                ))
                 .with_mint(mint!(
                     (
                         "5fb286e39c3cda5a5abd17501c17b01987ebfa282df129c4df1bf27e",
@@ -601,15 +591,11 @@ mod tests {
                 1
             )])
             .with_outputs(vec![output!(script_address.clone())])
-            .with_change_strategy(Box::new(|change, outputs| {
-                outputs.push(
-                    output!(
-                        "addr_test1qzpvzu5atl2yzf9x4eetekuxkm5z02kx5apsreqq8syjum6274ase8lkeffp39narear74ed0nf804e5drfm9l99v4eq3ecz8t",
-                        change
-                    )
-                );
-                Ok(())
-            }))
+            .with_change_strategy(ChangeStrategy::as_last_output(
+                address_test!(
+                    "addr_test1qzpvzu5atl2yzf9x4eetekuxkm5z02kx5apsreqq8syjum6274ase8lkeffp39narear74ed0nf804e5drfm9l99v4eq3ecz8t",
+                )
+            ))
             .ok()
         })
         .unwrap();
@@ -631,8 +617,8 @@ mod tests {
             let change_script = script.clone();
 
             tx.with_inputs(utxo.keys().cloned())
-                .with_change_strategy(Box::new(move |change, outputs| {
-                    outputs.push(
+                .with_change_strategy(ChangeStrategy::new(move |change, outputs| {
+                    outputs.push_back(
                         output!(change_address, change).with_plutus_script(change_script.clone()),
                     );
                     Ok(())

--- a/rust/crates/cardano-tx-builder/src/cbor.rs
+++ b/rust/crates/cardano-tx-builder/src/cbor.rs
@@ -3,3 +3,21 @@
 //  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 pub use pallas_codec::minicbor::*;
+use std::convert::Infallible;
+
+/// A trait mostly for convenience, as we often end up writing bytes to CBOR. The original
+/// [`minicbor::Encode::encode`] makes room for encoding into any Writer type, and thus provides
+/// the ability to fail.
+///
+/// When writing bytes to a vector, the operation is however Infaillible.
+pub trait ToCbor {
+    fn to_cbor(&self) -> Vec<u8>;
+}
+
+impl<T: Encode<()>> ToCbor for T {
+    fn to_cbor(&self) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        let _: Result<(), encode::Error<Infallible>> = encode(self, &mut bytes);
+        bytes
+    }
+}

--- a/rust/crates/cardano-tx-builder/src/lib.rs
+++ b/rust/crates/cardano-tx-builder/src/lib.rs
@@ -17,6 +17,7 @@ pub use cardano::{
     input::Input,
     network_id::NetworkId,
     output::Output,
+    output::change_strategy::ChangeStrategy,
     plutus_data::PlutusData,
     plutus_script::PlutusScript,
     plutus_version::PlutusVersion,

--- a/rust/crates/cardano-tx-builder/src/pallas.rs
+++ b/rust/crates/cardano-tx-builder/src/pallas.rs
@@ -3,5 +3,6 @@
 //  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 pub use pallas_addresses::*;
+pub use pallas_codec::utils::*;
 pub use pallas_crypto::*;
 pub use pallas_primitives::{alonzo::BigInt, conway::*, *};


### PR DESCRIPTION
- :round_pushpin: **delay-compute change according to a user-provided strategy.**
  
- :round_pushpin: **cleanup change strategy API and define a 'ChangeStrategy' type, with default strategies.**
  
- :round_pushpin: **account for possible redeemers in spend inputs.**
  
- :round_pushpin: **move always-succeed script & address in a static var**
