### PR TITLE
Fix typo in adaptor number parsing.

### DIFF
--- a/adaptor/src/handlers/quote.mjs
+++ b/adaptor/src/handlers/quote.mjs
@@ -12,7 +12,7 @@ export function get_quote(lightning) {
     const recipient = quote.destination;
 
     const expiry = new Date(
-      Number.parseInt(quote.timestamp, 10) + Number.parseInt(quote.expiry + 10),
+      Number.parseInt(quote.timestamp, 10) + Number.parseInt(quote.expiry, 10),
     );
 
     const amount = BigInt(quote.num_msat);


### PR DESCRIPTION
Just noticed that while randomly looking at the code.