### PR TITLE
Fixing issues with pay pipeline:

### DIFF
--- a/rust/crates/bln-client/justfile
+++ b/rust/crates/bln-client/justfile
@@ -38,8 +38,7 @@ encode-hash hash:
 
 # Check node health (shows which node is active)
 health:
-    @echo "Connecting to node using {{dot_file}}..."
-    @just node={{node}} _request GET "/v1/getinfo" | jq '{alias: .alias, identity_pubkey: .identity_pubkey, synced: .synced_to_chain}'
+    @just node={{node}} _request GET "/v1/getinfo" | jq '{alias: .alias, identity_pubkey: .identity_pubkey, synced: .synced_to_chain, block_height : .block_height}'
 
 # --- Invoice Commands ---
 # Decode a bolt11 invoice to see destination and amount
@@ -56,6 +55,9 @@ add-invoice amt_msat memo="":
 
 # --- Payment Commands ---
 
+get-routes pub_key amt:
+    @just node={{node}} _request GET "/v1/graph/routes/{{pub_key}}/{{amt}}"
+
 # Pay a lightning invoice
 pay invoice:
     @B64_PREIMAGE=$(just node={{node}} _request POST "/v1/channels/transactions" "{\"payment_request\": \"{{invoice}}\"}" | jq -r '.payment_preimage'); \
@@ -71,7 +73,7 @@ pay2 invoice:
     @RAW_RESPONSE=$(just _request POST "/v2/router/send" "{\"payment_request\": \"{{invoice}}\"}"); \
     PREIMAGE=$(echo "$RAW_RESPONSE" | jq -r 'select(.result.status == "SUCCEEDED") | .result.payment_preimage'); \
     if [ -n "$PREIMAGE" ] && [ "$PREIMAGE" != "null" ]; then \
-        echo "Success! Preimage: $PREIMAGE"; \
+        echo "$PREIMAGE"; \
     else \
         echo "--- PAYMENT NOT SUCCEEDED ---"; \
         echo "Could not find a SUCCEEDED status in the stream. Full response follows:"; \
@@ -81,6 +83,8 @@ pay2 invoice:
 # List payments
 payments short="":
     @just node={{node}} _request GET "/v1/payments" | jq 'if .payments then (if "{{short}}" == "--short" then .payments[] | {status: .status, hash: .payment_hash, value: .value_sat} else . end) else . end'
+
+
 
 # --- Utility ---
 

--- a/rust/crates/bln-client/src/lnd/client.rs
+++ b/rust/crates/bln-client/src/lnd/client.rs
@@ -224,7 +224,7 @@ impl Api for Client {
     async fn pay(&self, req: PayRequest) -> crate::Result<PayResponse> {
         let blocks = req.relative_timeout.as_secs() / self.config.block_time.as_secs();
         let body = router_send::Request {
-            cltv_limit: Some(std::cmp::max(blocks, self.config.min_cltv)),
+            cltv_limit: Some(blocks),
             fee_limit_msat: Some(req.fee_limit),
             payment_request: Some(req.invoice.into()),
             ..Default::default()

--- a/rust/crates/bln-client/src/types/invoice.rs
+++ b/rust/crates/bln-client/src/types/invoice.rs
@@ -5,7 +5,7 @@ use lightning_invoice::{
     SignedRawBolt11Invoice,
 };
 use lightning_types::features::Bolt11InvoiceFeatures;
-use std::time::Duration;
+use std::{fmt::Display, str::FromStr, time::Duration};
 
 pub mod error;
 
@@ -28,18 +28,24 @@ pub struct Invoice {
     pub payment_metadata: Option<Vec<u8>>,
 }
 
-impl TryFrom<&str> for Invoice {
-    type Error = InvoiceError;
+impl Display for Invoice {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.__raw)
+    }
+}
 
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+impl FromStr for Invoice {
+    type Err = InvoiceError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
         Invoice::try_from(
-            value
-                .parse::<SignedRawBolt11Invoice>()
+            s.parse::<SignedRawBolt11Invoice>()
                 .map_err(|_| InvoiceError::Parse)?,
         )
     }
 }
 
+// FIXME :: This should be removed
 impl TryFrom<&String> for Invoice {
     type Error = InvoiceError;
 

--- a/rust/crates/konduit-client/src/main.rs
+++ b/rust/crates/konduit-client/src/main.rs
@@ -88,10 +88,14 @@ pub struct SquashProposal {
 impl fmt::Display for QuoteResponse {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(f, "\n--- Quote ---")?;
-        writeln!(f, "Index:    {}", self.index)?;
-        writeln!(f, "Lovelace: {}", self.amount)?;
-        writeln!(f, "Fee:      {} msat", self.routing_fee)?;
-        write!(f, "Timeout:  {} ms", self.relative_timeout)
+        writeln!(f, "Index          :  {}", self.index)?;
+        writeln!(f, "Amount    (Ada):  {}", self.amount)?;
+        writeln!(f, "Fee      (msat):  {}", self.routing_fee)?;
+        writeln!(
+            f,
+            "Timeout (hours):  {:.2}",
+            self.relative_timeout / (1000 * 60 * 60)
+        )
     }
 }
 
@@ -223,7 +227,7 @@ impl Config {
         invoice_str: &str,
         quote: &QuoteResponse,
     ) -> anyhow::Result<SquashResponse> {
-        let invoice = bln_client::types::Invoice::try_from(invoice_str)?;
+        let invoice = invoice_str.parse::<bln_client::types::Invoice>()?;
         let lock = Lock(invoice.payment_hash);
 
         let now = SystemTime::now().duration_since(UNIX_EPOCH)?.as_millis() as u64;
@@ -271,7 +275,15 @@ impl Config {
                 // 3. Verify 'current' matches local expectations if applicable
                 println!("(Verification steps omitted...)");
 
-                if self.auto_confirm || confirm("Verify proposal and execute squash?")? {
+                if self.auto_confirm
+                    || confirm(
+                        format!(
+                            "Verify proposal and execute squash?\n{}",
+                            serde_json::to_string_pretty(&proposal).unwrap()
+                        )
+                        .as_str(),
+                    )?
+                {
                     println!("Executing squash with proposed body...");
                     let next_res = self.execute_squash(proposal.proposal).await?;
                     // Recursively handle if it's still incomplete (e.g. multi-step sync)
@@ -314,10 +326,8 @@ async fn main() -> anyhow::Result<()> {
         }
         Commands::Pay { invoice } => config.handle_full_pay_flow(invoice).await?,
         Commands::Squash => {
-            if config.auto_confirm || confirm("Manually squash latest state?")? {
-                let res = config.execute_squash(SquashBody::zero()).await?;
-                config.handle_squash_response(res).await?;
-            }
+            let res = config.execute_squash(SquashBody::zero()).await?;
+            config.handle_squash_response(res).await?;
         }
     }
 

--- a/rust/crates/konduit-data/src/receipt.rs
+++ b/rust/crates/konduit-data/src/receipt.rs
@@ -81,7 +81,7 @@ impl Receipt {
 
     // FIXME :: Not currently used
     pub fn capacity(&self) -> usize {
-        MAX_UNSQUASHED - self.cheques.len()
+        MAX_UNSQUASHED.saturating_sub(self.cheques.len())
     }
 
     pub fn useds(&self, useds: Vec<Used>) -> Vec<Used> {

--- a/rust/crates/konduit-server/src/models.rs
+++ b/rust/crates/konduit-server/src/models.rs
@@ -1,8 +1,9 @@
 use crate::Channel;
+use bln_client::types::Invoice;
 use cardano_tx_builder::Signature;
 use konduit_data::{ChequeBody, L1Channel, Receipt, SquashProposal};
 use serde::{Deserialize, Serialize};
-use serde_with::serde_as;
+use serde_with::{DisplayFromStr, serde_as};
 use std::collections::BTreeMap;
 
 pub use konduit_data::{Keytag, Stage};
@@ -10,7 +11,7 @@ pub use konduit_data::{Keytag, Stage};
 #[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Info {
-    #[serde(with = "hex")]
+    #[serde_as(as = "serde_with::hex::Hex")]
     pub adaptor_key: [u8; 32],
     pub close_period: u64,
     pub fee: u64,
@@ -37,10 +38,27 @@ pub type ShowResponse = BTreeMap<Keytag, Channel>;
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Secrets(Vec<[u8; 32]>);
 
+#[serde_as]
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub enum QuoteBody {
     Simple(SimpleQuote),
-    Bolt11(String),
+    Bolt11(#[serde_as(as = "DisplayFromStr")] Invoice),
+}
+
+impl QuoteBody {
+    pub fn amount_msat(&self) -> u64 {
+        match self {
+            QuoteBody::Simple(simple_quote) => simple_quote.amount_msat,
+            QuoteBody::Bolt11(invoice) => invoice.amount_msat,
+        }
+    }
+
+    pub fn payee(&self) -> [u8; 33] {
+        match self {
+            QuoteBody::Simple(simple_quote) => simple_quote.payee,
+            QuoteBody::Bolt11(invoice) => invoice.payee_compressed,
+        }
+    }
 }
 
 #[serde_as]


### PR DESCRIPTION
- fix + clarify cltv calculation
- use "capacity" to mean "remaining cheque slots" (BLN speak)

In the process:

- parse invoice directly in serde methods of server.
- print times in hours